### PR TITLE
Header / footer metrics should respect UITableView.sectionHeaderHeight / sectionFooterHeight

### DIFF
--- a/AST/ASTViewController.m
+++ b/AST/ASTViewController.m
@@ -815,7 +815,7 @@ static ASTSection* sectionFromObject( id sectionObject )
 		return result;
 	}
 	
-	return UITableViewAutomaticDimension;
+	return self.tableView.sectionHeaderHeight;
 }
 
 //------------------------------------------------------------------------------
@@ -842,7 +842,7 @@ static ASTSection* sectionFromObject( id sectionObject )
 		return result;
 	}
 	
-	return UITableViewAutomaticDimension;
+	return self.tableView.sectionFooterHeight;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I propose adjusting the header/footer height delegate method implementations in the `ASTViewController` to be more consistent with standard UIKit behavior. The fact that `ASTViewController` implements `tableView:heightForHeaderInSection` means that a client cannot set the `sectionHeaderHeight` property on the view controller's table view directly. 

Instead of returning `UITableViewAutomaticDimension` from these delegate method implementations, the fallback can be the table view's  `sectionHeaderHeight` / `sectionFooterHeight`. In my testing this will still be equal to `UITableViewAutomaticDimension` by default (although, of course, I could not find that behavior documented.)

Here is the relevant documentation:

<img width="739" alt="screen shot 2017-11-01 at 4 20 39 pm" src="https://user-images.githubusercontent.com/3003676/32298581-a9807178-bf20-11e7-9cf0-5aad5816ae69.png">